### PR TITLE
Single Licensing File

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,4 @@
+//Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
 module.exports = function(grunt) {
 	require('load-grunt-tasks')(grunt);
 	grunt.initConfig({

--- a/License.txt
+++ b/License.txt
@@ -1,0 +1,7 @@
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lib/client/browser.js
+++ b/lib/client/browser.js
@@ -1,40 +1,4 @@
-/*
-Copyright © Microsoft Open Technologies, Inc.
-All Rights Reserved       
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-http://www.apache.org/licenses/LICENSE-2.0
- 
-THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
- 
-See the Apache 2 License for the specific language governing permissions and limitations under the License.
-*/
-
-/*
-The MIT License
- 
-Copyright (C) 2013 Gábor Molnár <gabor@molnar.es>
- 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
- 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
- 
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-*/
-
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
 
 var spawn = require('child_process').spawn;
 

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1,40 +1,4 @@
-/*
-Copyright © Microsoft Open Technologies, Inc.
-All Rights Reserved       
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-http://www.apache.org/licenses/LICENSE-2.0
- 
-THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
- 
-See the Apache 2 License for the specific language governing permissions and limitations under the License.
-*/
-
-/*
-The MIT License
- 
-Copyright (C) 2013 Gábor Molnár <gabor@molnar.es>
- 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
- 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
- 
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-*/
-
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
 
 var glob = require('glob').sync,
 	expect = require('chai').expect,

--- a/lib/client/tests/compression/huge-index-test.js
+++ b/lib/client/tests/compression/huge-index-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // > [4.3. Header Compression and Decompression](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-4.3)
 // >
 // > ...

--- a/lib/client/tests/compression/invalid-data-1-test.js
+++ b/lib/client/tests/compression/invalid-data-1-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // > [4.3. Header Compression and Decompression](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-4.3)
 // >
 // > ...

--- a/lib/client/tests/compression/invalid-data-2-test.js
+++ b/lib/client/tests/compression/invalid-data-2-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // > [4.3. Header Compression and Decompression](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-4.3)
 // >
 // > ...

--- a/lib/client/tests/compression/invalid-data.js
+++ b/lib/client/tests/compression/invalid-data.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 var http2 = require('http2-protocol');
 
 module.exports = function(socket, log, callback, compressedData) {

--- a/lib/client/tests/framing/oversized-ping-test.js
+++ b/lib/client/tests/framing/oversized-ping-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // [From the spec](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-6.7):
 //
 //     In addition to the frame header, PING frames MUST contain 8 octets of

--- a/lib/client/tests/multiplexing/invalid-level-data-test.js
+++ b/lib/client/tests/multiplexing/invalid-level-data-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // [From the spec](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-6.7):
 //
 //     DATA frames MUST be associated with a stream. If a DATA frame is

--- a/lib/client/tests/multiplexing/invalid-level-goaway-test.js
+++ b/lib/client/tests/multiplexing/invalid-level-goaway-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // [From the spec](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-6.8):
 //
 //     The GOAWAY frame applies to the connection, not a specific stream.

--- a/lib/client/tests/multiplexing/invalid-level-headers-test.js
+++ b/lib/client/tests/multiplexing/invalid-level-headers-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // [From the spec](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-6.2):
 //
 //     HEADERS frames MUST be associated with a stream.  If a HEADERS frame

--- a/lib/client/tests/multiplexing/invalid-level-ping-test.js
+++ b/lib/client/tests/multiplexing/invalid-level-ping-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // [From the spec](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-6.7):
 //
 //     PING frames are not associated with any individual stream. If a PING

--- a/lib/client/tests/multiplexing/invalid-level-priority-test.js
+++ b/lib/client/tests/multiplexing/invalid-level-priority-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // [From the spec](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-6.3):
 //
 //     PRIORITY frame is received with a stream identifier of 0x0, the

--- a/lib/client/tests/multiplexing/invalid-level-push-promise-test.js
+++ b/lib/client/tests/multiplexing/invalid-level-push-promise-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // [From the spec](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-6.6):
 //
 //     ... If the stream identifier field specifies the value

--- a/lib/client/tests/multiplexing/invalid-level-rst-stream.js
+++ b/lib/client/tests/multiplexing/invalid-level-rst-stream.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // [From the spec](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-6.4):
 //
 //     RST_STREAM frames MUST be associated with a stream.  If a RST_STREAM

--- a/lib/client/tests/multiplexing/invalid-level-settings.js
+++ b/lib/client/tests/multiplexing/invalid-level-settings.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // [From the spec](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-6.5):
 //
 //     SETTINGS frames always apply to a connection, never a single stream.

--- a/lib/client/tests/push/invalid-promised-id-1-test.js
+++ b/lib/client/tests/push/invalid-promised-id-1-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // > [5.1.1. Stream Identifiers](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-5.1.1)
 // >
 // > Streams are identified with an unsigned 31-bit integer. Streams

--- a/lib/client/tests/push/invalid-promised-id-2-test.js
+++ b/lib/client/tests/push/invalid-promised-id-2-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // > [5.1.1. Stream Identifiers](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-5.1.1)
 // >
 // > Streams are identified with an unsigned 31-bit integer. Streams

--- a/lib/client/tests/push/invalid-promised-id-3-test.js
+++ b/lib/client/tests/push/invalid-promised-id-3-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // > [5.1.1. Stream Identifiers](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-5.1.1)
 // >
 // > Streams are identified with an unsigned 31-bit integer. Streams

--- a/lib/client/tests/stream/data-when-closed-test.js
+++ b/lib/client/tests/stream/data-when-closed-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-closed.js
 
 var invalidFrameWhenClosedTest = require('./invalid-frame-when-closed');

--- a/lib/client/tests/stream/data-when-idle-test.js
+++ b/lib/client/tests/stream/data-when-idle-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-idle.js
 
 var invalidFrameWhenIdleTest = require('./invalid-frame-when-idle');

--- a/lib/client/tests/stream/data-when-reserved-remote-test.js
+++ b/lib/client/tests/stream/data-when-reserved-remote-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-reserved-remote.js
 
 var invalidFrameWhenReservedRemoteTest = require('./invalid-frame-when-reserved-remote');

--- a/lib/client/tests/stream/invalid-frame-when-closed.js
+++ b/lib/client/tests/stream/invalid-frame-when-closed.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // > [5.1. Stream States](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-5.1)
 // >
 // > ...

--- a/lib/client/tests/stream/invalid-frame-when-idle.js
+++ b/lib/client/tests/stream/invalid-frame-when-idle.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // > [5.1. Stream States](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-5.1)
 // >
 // > ...

--- a/lib/client/tests/stream/invalid-frame-when-reserved-remote.js
+++ b/lib/client/tests/stream/invalid-frame-when-reserved-remote.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // > [5.1. Stream States](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-5.1)
 // >
 // > ...

--- a/lib/client/tests/stream/priority-when-closed-test.js
+++ b/lib/client/tests/stream/priority-when-closed-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-closed.js
 
 var invalidFrameWhenClosedTest = require('./invalid-frame-when-closed');

--- a/lib/client/tests/stream/priority-when-idle-test.js
+++ b/lib/client/tests/stream/priority-when-idle-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-idle.js
 
 var invalidFrameWhenIdleTest = require('./invalid-frame-when-idle');

--- a/lib/client/tests/stream/priority-when-reserved-remote-test.js
+++ b/lib/client/tests/stream/priority-when-reserved-remote-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-reserved-remote.js
 
 var invalidFrameWhenReservedRemoteTest = require('./invalid-frame-when-reserved-remote');

--- a/lib/client/tests/stream/push-promise-when-closed-test.js
+++ b/lib/client/tests/stream/push-promise-when-closed-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-closed.js
 
 var invalidFrameWhenClosedTest = require('./invalid-frame-when-closed');

--- a/lib/client/tests/stream/push-promise-when-idle-test.js
+++ b/lib/client/tests/stream/push-promise-when-idle-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-idle.js
 
 var invalidFrameWhenIdleTest = require('./invalid-frame-when-idle');

--- a/lib/client/tests/stream/push-promise-when-idle.js
+++ b/lib/client/tests/stream/push-promise-when-idle.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-idle.js
 
 var invalidFrameWhenIdleTest = require('./invalid-frame-when-idle');

--- a/lib/client/tests/stream/push-promise-when-reserved-remote-test.js
+++ b/lib/client/tests/stream/push-promise-when-reserved-remote-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-reserved-remote.js
 
 var invalidFrameWhenReservedRemoteTest = require('./invalid-frame-when-reserved-remote');

--- a/lib/client/tests/stream/reservation-when-closed-test.js
+++ b/lib/client/tests/stream/reservation-when-closed-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // > [6.6. PUSH_PROMISE](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-6.6)
 // >
 // > ...

--- a/lib/client/tests/stream/reservation-when-reserved-remote-test.js
+++ b/lib/client/tests/stream/reservation-when-reserved-remote-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // > [6.6. PUSH_PROMISE](http://tools.ietf.org/html/draft-ietf-httpbis-http2-06#section-6.6)
 // >
 // > ...

--- a/lib/client/tests/stream/rst-stream-when-closed-test.js
+++ b/lib/client/tests/stream/rst-stream-when-closed-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-closed.js
 
 var invalidFrameWhenClosedTest = require('./invalid-frame-when-closed');

--- a/lib/client/tests/stream/rst-stream-when-idle-test.js
+++ b/lib/client/tests/stream/rst-stream-when-idle-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-idle.js
 
 var invalidFrameWhenIdleTest = require('./invalid-frame-when-idle');

--- a/lib/client/tests/stream/window-update-when-closed-test.js
+++ b/lib/client/tests/stream/window-update-when-closed-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-closed.js
 
 var invalidFrameWhenClosedTest = require('./invalid-frame-when-closed');

--- a/lib/client/tests/stream/window-update-when-idle-test.js
+++ b/lib/client/tests/stream/window-update-when-idle-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-idle.js
 
 var invalidFrameWhenIdleTest = require('./invalid-frame-when-idle');

--- a/lib/client/tests/stream/window-update-when-reserved-remote-test.js
+++ b/lib/client/tests/stream/window-update-when-reserved-remote-test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
+
 // See ../invalid-frame-when-reserved-remote.js
 
 var invalidFrameWhenReservedRemoteTest = require('./invalid-frame-when-reserved-remote');

--- a/lib/client/tests/template-test.js
+++ b/lib/client/tests/template-test.js
@@ -1,39 +1,4 @@
-/*
-Copyright © Microsoft Open Technologies, Inc.
-All Rights Reserved       
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-http://www.apache.org/licenses/LICENSE-2.0
- 
-THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
- 
-See the Apache 2 License for the specific language governing permissions and limitations under the License.
-*/
-
-/*
-The MIT License
- 
-Copyright (C) 2013 Gábor Molnár <gabor@molnar.es>
- 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
- 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
- 
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-*/
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. Licensed under the BSD 2-Clause License.
 
 /* 
 This is a test template. 


### PR DESCRIPTION
Removed long copyright headers from all files, created a BSD Clause 2 license file.

Fixed issue https://github.com/http2/http2-test/issues/2
